### PR TITLE
Add docker build without trivy

### DIFF
--- a/.github/workflows/docker-build-image-without-trivy.yml
+++ b/.github/workflows/docker-build-image-without-trivy.yml
@@ -1,0 +1,50 @@
+name: "Build Docker Image"
+
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        required: true
+        type: string
+      app_version:
+        required: false
+        type: string
+        default: "*"
+      working_directory:
+        required: true
+        type: string
+      dockerfile:
+        required: false
+        type: string
+        default: Dockerfile
+
+jobs:
+  build-image:
+    name: Build Docker image to make sure it works
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Printing Inputs
+        run: |
+          echo "app_name: ${{ inputs.app_name }}"
+          echo "app_version: ${{ inputs.app_version }}"
+          echo "working_directory: ${{ inputs.working_directory }}"
+          echo "dockerfile: ${{ inputs.dockerfile }}"
+
+      - name: Build from Dockerfile
+        id: build-image
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          tags: "${{ inputs.app_name }}:latest"
+          context: "./${{ inputs.working_directory }}"
+          file: "./${{ inputs.working_directory }}/${{ inputs.dockerfile }}"
+          build-args: |
+            APP_NAME=${{ inputs.app_name }}
+            APP_VERSION=${{ inputs.app_version }}
+


### PR DESCRIPTION
Private repos cannot have trivy scan. This will be for private repos that cannot have it.
